### PR TITLE
WSAD Camera movement

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -39,6 +39,10 @@ gdscript/warnings/static_called_on_instance=0
 window/size/viewport_width=1920
 window/size/viewport_height=1080
 
+[dotnet]
+
+project/assembly_name="Open RTS"
+
 [gui]
 
 timers/tooltip_delay_sec=0.0
@@ -78,6 +82,26 @@ frame_incrementer_step={
 toggle_diagnostic_mode={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194332,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
+move_map_up={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":119,"echo":false,"script":null)
+]
+}
+move_map_down={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":115,"echo":false,"script":null)
+]
+}
+move_map_left={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":97,"echo":false,"script":null)
+]
+}
+move_map_right={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":100,"echo":false,"script":null)
 ]
 }
 

--- a/source/match/IsometricCamera3D.gd
+++ b/source/match/IsometricCamera3D.gd
@@ -50,6 +50,10 @@ func _physics_process(delta):
 		global_translate(movement_vector_3d)
 		_align_position_to_bounding_planes()
 
+func _process(_delta):
+	if( !_is_rotating() ):
+		_move(  )
+	
 
 func _unhandled_input(event):
 	if event is InputEventMouseButton:
@@ -69,8 +73,6 @@ func _unhandled_input(event):
 		var mouse_pos = event.position
 		if _is_rotating():
 			_rotate(mouse_pos)
-		else:
-			_move(mouse_pos)
 
 
 func set_size_safely(a_size):
@@ -146,18 +148,25 @@ func _rotate(mouse_pos):
 	global_transform = global_transform.looking_at(_pivot_point_3d, Vector3(0, 1, 0))
 
 
-func _move(mouse_pos):
+func _move():
 	var viewport_size = get_viewport().size
-	_movement_vector_2d = Vector2(
-		(
-			-1 * int(mouse_pos.x <= screen_margin_for_movement)
-			+ 1 * int(mouse_pos.x >= viewport_size.x - screen_margin_for_movement)
-		),
-		(
-			-1 * int(mouse_pos.y <= screen_margin_for_movement)
-			+ 1 * int(mouse_pos.y >= viewport_size.y - screen_margin_for_movement)
-		)
-	)
+	var mouse_pos = get_viewport().get_mouse_position()
+	
+	var xAxis = Input.get_axis("move_map_left", "move_map_right")
+	var yAxis = Input.get_axis("move_map_up", "move_map_down")
+	_movement_vector_2d = Vector2( xAxis, yAxis )
+	
+	if( mouse_pos.x <= screen_margin_for_movement ):
+		_movement_vector_2d.x = -1;
+		
+	if( mouse_pos.x >= viewport_size.x - screen_margin_for_movement ):
+		_movement_vector_2d.x = 1;
+			
+	if( mouse_pos.y <= screen_margin_for_movement ):
+		_movement_vector_2d.y = -1;
+		
+	if( mouse_pos.y >= viewport_size.y - screen_margin_for_movement ):
+		_movement_vector_2d.y = 1;
 
 
 func _is_rotating():
@@ -229,3 +238,4 @@ func _target_position_to_camera_position(target_position: Vector3):
 	var intersection = target_plane.intersects_ray(global_transform.origin, camera_ray)
 	var offset_yless = (target_position - intersection) * Vector3(1, 0, 1)
 	return global_transform.origin + offset_yless
+


### PR DESCRIPTION
Camera movement was moved from _unhandled_input to _process, otherwise the two input was interfering each other, now the mouse input will overwrite the keyboard.

Also _move does not get the mouse position as parameter rather gets directly from viewport